### PR TITLE
Enable support for lines prefixed with occurrences counters

### DIFF
--- a/lib_trainer/detection_rules/multiword_detector.py
+++ b/lib_trainer/detection_rules/multiword_detector.py
@@ -28,7 +28,7 @@ class MultiWordDetector:
 
     """
 
-    def __init__(self, threshold = 5, min_len = 4, max_len = 21):
+    def __init__(self, threshold = 5, min_len = 4, max_len = 21, prefixcount=False):
         """
         Initialize the Multi-word detector
 
@@ -63,6 +63,7 @@ class MultiWordDetector:
         # a multiword we can walk down it trying to find matches
         #
         self.lookup = {}
+        self.prefixcount = prefixcount
 
     def train(self, input_password):
         """
@@ -77,6 +78,17 @@ class MultiWordDetector:
         words, they shouldn't take up a lot of space
 
         """
+        # Remove the digit when prefixcount is anbled and save it seperate
+        if self.prefixcount == True:
+            # Something lstrip might cause some issues when a paragraph seperator is in a password
+            # We simply ignore those lines.
+            try:
+                n = int(input_password.lstrip().split(' ')[0])
+                input_password = ' '.join(input_password.lstrip().split(' ')[1:])
+            except ValueError:
+                return False
+        else:
+            n = 1
 
         # Quick bail out if the input password is too short or too long
         if len(input_password) < self.min_len:
@@ -121,10 +133,10 @@ class MultiWordDetector:
                     if run_len >= self.min_len:
                         # If the word hasn't been seen before
                         if "count" not in index:
-                            index["count"] = 1
+                            index["count"] = n
 
                         else:
-                            index["count"] += 1
+                            index["count"] += n
 
                     # Reset the index and run length
                     run_len = 0
@@ -136,10 +148,10 @@ class MultiWordDetector:
             if run_len >= self.min_len:
                 # If the word hasn't been seen before
                 if "count" not in index:
-                    index["count"] = 1
+                    index["count"] = n
 
                 else:
-                    index["count"] += 1
+                    index["count"] += n
 
             # Reset the index and run length
             run_len = 0

--- a/lib_trainer/omen/alphabet_generator.py
+++ b/lib_trainer/omen/alphabet_generator.py
@@ -18,7 +18,7 @@ class AlphabetGenerator:
 
     """
 
-    def __init__(self, alphabet_size, ngram):
+    def __init__(self, alphabet_size, ngram, prefixcount = False):
         """
         Initialize the alphabet generator
 
@@ -32,6 +32,7 @@ class AlphabetGenerator:
         """
         self.alphabet_size = alphabet_size
         self.ngram = ngram
+        self.prefixcount = prefixcount
 
         ## Dictionary used for quick lookups during training
         #
@@ -45,6 +46,17 @@ class AlphabetGenerator:
         """
         Parse one password
         """
+        # Remove the digit when prefixcount is anbled and save it seperate
+        if self.prefixcount == True:
+            # Something lstrip might cause some issues when a paragraph seperator is in a password
+            # We simply ignore those lines.
+            try:
+                n = int(password.lstrip().split(' ')[0])
+                password = ' '.join(password.lstrip().split(' ')[1:])
+            except ValueError:
+                return False
+        else:
+            n = 1
 
         # Make sure it is long enough
         # This is to weed out things like weird one character line breaks
@@ -61,11 +73,11 @@ class AlphabetGenerator:
 
             # If we have seen this letter before
             if letter in self.dictionary:
-                self.dictionary[letter] += 1
+                self.dictionary[letter] += n
 
             # If this is the first time we've seen this letter
             else:
-                self.dictionary[letter] = 1
+                self.dictionary[letter] = n
 
         return
 

--- a/lib_trainer/omen/alphabet_lookup.py
+++ b/lib_trainer/omen/alphabet_lookup.py
@@ -21,7 +21,7 @@ class AlphabetLookup:
 
     """
 
-    def __init__(self, alphabet, ngram, min_length = 1, max_length = 21):
+    def __init__(self, alphabet, ngram, min_length = 1, max_length = 21, prefixcount = False):
         """
         Basic initialization function
 
@@ -85,10 +85,24 @@ class AlphabetLookup:
         # as a simple list vs dictionary
         self.ln_lookup = [0]* max_length
 
+        # prefixcount value
+        self.prefixcount = prefixcount 
+
     def parse(self, password):
         """
         Parses the input password and updates the global counts
         """
+        # Remove the digit when prefixcount is anbled and save it seperate
+        if self.prefixcount == True:
+            # Something lstrip might cause some issues when a paragraph seperator is in a password
+            # We simply ignore those lines.
+            try:
+                n = int(password.lstrip().split(' ')[0])
+                password = ' '.join(password.lstrip().split(' ')[1:])
+            except ValueError:
+                return False
+        else:
+            n = 1
 
         # Reject if too short or too long
         pw_len = len(password)
@@ -97,8 +111,8 @@ class AlphabetLookup:
 
         # Update the length counts
         # List is 0 indexed so subtract -1 from actual length
-        self.ln_lookup[pw_len - 1] += 1
-        self.ln_counter += 1
+        self.ln_lookup[pw_len - 1] += n
+        self.ln_counter += n
 
         ## Loop through the entire password
         #
@@ -131,8 +145,8 @@ class AlphabetLookup:
             ## Handle if it is the IP
             #
             if i == 0:
-                index['ip_count'] += 1
-                self.ip_counter += 1
+                index['ip_count'] += n
+                self.ip_counter += n
 
             ## Handle the CP info
             #
@@ -142,18 +156,18 @@ class AlphabetLookup:
                 if end_char not in index['next_letter']:
                     # Check if this char is in the alphabet
                     if self.is_in_alphabet(end_char):
-                        index['next_letter'][end_char] = 1
-                        index['cp_count'] += 1
+                        index['next_letter'][end_char] = n
+                        index['cp_count'] += n
                 # Have seen this before
                 else:
-                    index['next_letter'][end_char] += 1
-                    index['cp_count'] += 1
+                    index['next_letter'][end_char] += n
+                    index['cp_count'] += n
 
             ##Handle the EP info
             #
             else:
-                index['ep_count'] += 1
-                self.ep_counter +=1
+                index['ep_count'] += n
+                self.ep_counter += n
 
         return
 

--- a/lib_trainer/prince_metrics.py
+++ b/lib_trainer/prince_metrics.py
@@ -16,7 +16,7 @@ less likely.
 """
 
 
-def prince_evaluation(count_prince, section_list):
+def prince_evaluation(count_prince, section_list, n=1):
     """
     Save any statistics that would be useful to generating PRINCE wordlists
 
@@ -37,4 +37,4 @@ def prince_evaluation(count_prince, section_list):
 
     #Loop through the section list and add it to the PRINCE counts
     for item in section_list:
-        count_prince[item[1]] += 1
+        count_prince[item[1]] += n

--- a/lib_trainer/run_trainer.py
+++ b/lib_trainer/run_trainer.py
@@ -74,13 +74,17 @@ def run_trainer(program_info, base_directory):
     print("------------")
                     
     # Initialize the alphabet generator to learn the alphabet
-    ag = AlphabetGenerator(program_info['alphabet_size'], program_info['ngram'])
+    ag = AlphabetGenerator(
+                        program_info['alphabet_size'],
+                        program_info['ngram'],
+                        program_info['prefixcount'])
     
     # Intitialize the multi-word detector
     multiword_detector = MultiWordDetector(
                             threshold = 5,
                             min_len = 4,
-                            max_len = 21)
+                            max_len = 21,
+                            prefixcount=program_info['prefixcount'])
 
     # Loop until we hit the end of the file
     try:
@@ -123,7 +127,7 @@ def run_trainer(program_info, base_directory):
     print()
 
     # Perform duplicate detection and warn user if no duplicates were found
-    if not file_input.duplicates_found:
+    if not file_input.duplicates_found and not program_info['prefixcount']:
         print()
         print("WARNING:")
         print(f"   No duplicate passwords were detected in the first {file_input.num_to_look_for_duplicates} parsed passwords")
@@ -156,11 +160,12 @@ def run_trainer(program_info, base_directory):
     omen_trainer = AlphabetLookup(
         alphabet = program_info['alphabet'], 
         ngram = program_info['ngram'],
-        max_length = program_info['max_len']
+        max_length = program_info['max_len'],
+        prefixcount=program_info['prefixcount']
         )
     
     # Initialize the PCFG Password parse
-    pcfg_parser = PCFGPasswordParser(multiword_detector)
+    pcfg_parser = PCFGPasswordParser(multiword_detector, prefixcount=program_info['prefixcount'])
     
     # Loop until we hit the end of the file
     try:

--- a/lib_trainer/unit_tests/test_omen_trainer.py
+++ b/lib_trainer/unit_tests/test_omen_trainer.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+
+#######################################################
+# Unit tests omen trainer
+#
+#######################################################
+
+import unittest
+import unittest.mock
+from collections import Counter
+
+## Functions and classes to tests
+#
+from ..omen.alphabet_generator import AlphabetGenerator
+## Responsible for testing the prefix count
+#
+# Note:
+# + = positive test, (valid input handling)
+# - = stress test, (invalid input handling) 
+#
+# ==Current Tests==
+# + Test simple password with a prefixcount
+#
+
+class Test_AlphabetGenerator_prefixcount(unittest.TestCase):
+    # Setup generator
+    ag = AlphabetGenerator(100, 4, prefixcount=True)
+    ag.process_password('500 Password123!')
+    assert ag.dictionary['P'] == 500

--- a/lib_trainer/unit_tests/test_pcfg_parse.py
+++ b/lib_trainer/unit_tests/test_pcfg_parse.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+
+#######################################################
+# Unit tests pcfg parser
+#
+#######################################################
+
+import unittest
+import unittest.mock
+from collections import Counter
+
+## Functions and classes to tests
+#
+from ..pcfg_password_parser import PCFGPasswordParser
+from ..detection_rules.multiword_detector import MultiWordDetector
+## Responsible for testing the prefix count
+#
+# Note:
+# + = positive test, (valid input handling)
+# - = stress test, (invalid input handling) 
+#
+# ==Current Tests==
+# + Test simple password with a prefixcount
+#
+
+class Test_PCFGPasswordParser_prefixcount(unittest.TestCase):
+    # Setup test MultiWord
+    multiword_detector = MultiWordDetector(
+                            threshold = 5,
+                            min_len = 4,
+                            max_len = 21,
+                            prefixcount=True)
+    # While we are here, lets test the multiword aswell
+    multiword_detector.train('500 Password123!')
+    assert multiword_detector.lookup == {'p': {'a': {'s': {'s': {'w': {'o': {'r': {'d': {'count': 500}}}}}}}}}
+
+    pcfg_parser = PCFGPasswordParser(multiword_detector, prefixcount=True)
+    pcfg_parser.parse('500 Password123!')
+
+    assert pcfg_parser.count_alpha[8] == Counter({'password': 500})

--- a/trainer.py
+++ b/trainer.py
@@ -133,6 +133,18 @@ def parse_command_line(program_info):
         action='store_true'
     )
 
+    # Prefix count
+    parser.add_argument(
+        '--prefixcount',
+        help = 'When enabled lines must be prefixed with a occurrences counter. Example:' +
+        '5 password123!. Meaning that password123! was 5 times in the dataset. This can happen ' +
+        'for dataset which were sorted and uniqued with sort | uniq -c | sort -rn for example. Default: ' +
+        str(program_info['prefixcount']),
+        default = program_info['prefixcount'],
+        action = 'store_true',
+        required = False,
+    )
+
     ## OMEN Options
     #
     # ngram is the size of the conditional probabilty strings to compare
@@ -214,6 +226,7 @@ def parse_command_line(program_info):
     program_info['encoding']= args.encoding
     program_info['comments'] = args.comments
     program_info['save_sensitive'] = args.save_sensitive
+    program_info['prefixcount'] = args.prefixcount
 
     # OMEN Options
     program_info['ngram'] = args.ngram
@@ -278,6 +291,7 @@ def main():
         'encoding':None,
         'comments':'',
         'save_sensitive': False,
+        'prefixcount': False,
 
         # OMEN Options
         'ngram': 4,


### PR DESCRIPTION
With the feature you are able to train on wordlist that have a count in front of them. Example:
Testdata.txt:
```
5 Password123!
6 Password321!
```

```
python3 trainer.py -t testdata.txt -r test --prefixcount -eutf8
```

Will result in Digit/3.txt:

```
321     0.5454545454545454
123     0.45454545454545453
```

Data can be generated with `sort | uniq -c | sort -rn`