### PR TITLE
Adding prefix count in the file_input function.

### DIFF
--- a/lib_trainer/future_research/my_leet_detector.py
+++ b/lib_trainer/future_research/my_leet_detector.py
@@ -342,16 +342,13 @@ class AsciiL33tDetector:
         file_input = TrainerFileInput(training_set, encoding)
         num_parsed_so_far = 0
         try:
-            password = file_input.read_password()
-            while password:
+            for password in file_input.read_password():
                 # Print status indicator if needed
                 num_parsed_so_far += 1
                 if num_parsed_so_far % 1000000 == 0:
                     print(str(num_parsed_so_far // 1000000) + ' Million')
                 # pcfg_parser.parse(password)
                 self.detect_l33t(password)
-                # Get the next password
-                password = file_input.read_password()
 
         except Exception as msg:
             traceback.print_exc(file=sys.stdout)

--- a/lib_trainer/run_trainer.py
+++ b/lib_trainer/run_trainer.py
@@ -57,7 +57,8 @@ def run_trainer(program_info, base_directory):
     # Initialize the file input to read passwords from
     file_input = TrainerFileInput(
                     program_info['training_file'],
-                    program_info['encoding'])
+                    program_info['encoding'],
+                    program_info['prefixcount'])
                     
     # Used for progress_bar
     num_parsed_so_far = 0
@@ -84,8 +85,7 @@ def run_trainer(program_info, base_directory):
 
     # Loop until we hit the end of the file
     try:
-        password = file_input.read_password()
-        while password:
+        for password in file_input.read_password():
 
             # Print status indicator if needed
             num_parsed_so_far += 1
@@ -97,9 +97,6 @@ def run_trainer(program_info, base_directory):
             
             # Train multiword detector
             multiword_detector.train(password)
-
-            # Get the next password
-            password = file_input.read_password()
 
     except Exception as msg:
         print(f"Exception: {msg}")
@@ -137,7 +134,8 @@ def run_trainer(program_info, base_directory):
     # Re-Initialize the file input to read passwords from
     file_input = TrainerFileInput(
                     program_info['training_file'], 
-                    program_info['encoding'])
+                    program_info['encoding'],
+                    program_info['prefixcount'])
                     
     # Reset progress_bar
     num_parsed_so_far = 0
@@ -164,8 +162,7 @@ def run_trainer(program_info, base_directory):
     
     # Loop until we hit the end of the file
     try:
-        password = file_input.read_password()
-        while password:
+        for password in file_input.read_password():
         
             # Print status indicator if needed
             num_parsed_so_far += 1
@@ -177,9 +174,6 @@ def run_trainer(program_info, base_directory):
             
             # Parse the pcfg info
             pcfg_parser.parse(password)
-            
-            # Get the next password
-            password = file_input.read_password()
                         
     except Exception as msg:
         traceback.print_exc(file=sys.stdout)
@@ -203,7 +197,8 @@ def run_trainer(program_info, base_directory):
     # Re-Initialize the file input to read passwords from
     file_input = TrainerFileInput(
                     program_info['training_file'], 
-                    program_info['encoding'])
+                    program_info['encoding'],
+                    program_info['prefixcount'])
                     
     # Reset progress_bar
     num_parsed_so_far = 0
@@ -220,8 +215,7 @@ def run_trainer(program_info, base_directory):
     omen_levels_count = Counter()
     ## Loop until we hit the end of the file
     try:
-        password = file_input.read_password()
-        while password:
+        for password in file_input.read_password():
         
             # Print status indicator if needed
             num_parsed_so_far += 1
@@ -231,9 +225,6 @@ def run_trainer(program_info, base_directory):
             # Find OMEN level of password
             level = find_omen_level(omen_trainer,password)
             omen_levels_count[level] += 1
-            
-            # Get the next password
-            password = file_input.read_password()
         
     except Exception as msg:
         traceback.print_exc(file=sys.stdout)

--- a/lib_trainer/unit_tests/test_trainer_file_input.py
+++ b/lib_trainer/unit_tests/test_trainer_file_input.py
@@ -36,6 +36,7 @@ from ..trainer_file_input import TrainerFileInput
 # + Check Valid password: invalid password, blank
 # + Check Valid password: invalid password, tab in password
 # + Read Input Passwords (FULL): Check to make sure correct number are read
+# + Read Prefix Passwords (FULL): Check to make sure correct number are read when prefixed with a count
 #
 class Test_File_Input_Checks(unittest.TestCase):
 
@@ -137,19 +138,53 @@ class Test_File_Input_Checks(unittest.TestCase):
             unittest.mock.mock_open(read_data=test_data)
         ):
         
-            file_input = TrainerFileInput("test_file",'ascii')
+            file_input = TrainerFileInput("test_file",'ascii',False)
         
             # Loop through all of the passwords
-            password = file_input.read_password()
-            while password:
-                password = file_input.read_password()                     
+            for password in file_input.read_password():
+                continue
             
         # Verify the number of passwords read and the raw results
         print("Num passwords:" + str(file_input.num_passwords))
         assert file_input.num_passwords == 8
         
         assert file_input.duplicates_found == True
+
+    def test_read_input_passwords_prefix(self):
+    
+        # Set up input
+        raw_test_data = "5 test1\n" \
+            "5 test2\r\n" \
+            "\r\n" \
+            "invalid1\t" \
+            "5 test3\n" \
+            "\n" \
+            "5 space1 \n" \
+            "5 space2\n" \
+            "5 sp ace3\n" \
+            "5 duplicate\n" \
+            "5 duplicate\r\r\n" \
+            "5 test4"
+        
+        test_data = raw_test_data
+        
+        # Patch file open and read data
+        with unittest.mock.patch(
+            'codecs.open', 
+            unittest.mock.mock_open(read_data=test_data)
+        ):
+        
+            file_input = TrainerFileInput("test_file",'ascii', prefixcount=True)
+        
+            # Loop through all of the passwords
+            for password in file_input.read_password():
+                continue
             
+        # Verify the number of passwords read and the raw results
+        assert file_input.num_passwords == 40
+        
+        assert file_input.duplicates_found == True
+
 
 if __name__ == '__main__':
     unittest.main()             

--- a/password_scorer.py
+++ b/password_scorer.py
@@ -236,7 +236,8 @@ def main():
     # Re-using the TrainerFileInput from the trainer
     file_input = TrainerFileInput(
                     program_info['input_file'],
-                    pw_parser.encoding)
+                    pw_parser.encoding,
+                    program_info['prefixcount'])
 
     # Open file for output
     writer = FileOutput(program_info['output_file'], pw_parser.encoding)

--- a/trainer.py
+++ b/trainer.py
@@ -133,6 +133,18 @@ def parse_command_line(program_info):
         action='store_true'
     )
 
+   # Prefix count
+    parser.add_argument(
+        '--prefixcount',
+        help = 'When enabled lines must be prefixed with a occurrences counter. Example:' +
+        '5 password123!. Meaning that password123! was 5 times in the dataset. This can happen ' +
+        'for dataset which were sorted and uniqued with sort | uniq -c | sort -rn for example. Default: ' +
+        str(program_info['prefixcount']),
+        default = program_info['prefixcount'],
+        action = 'store_true',
+        required = False,
+    )
+
     ## OMEN Options
     #
     # ngram is the size of the conditional probabilty strings to compare
@@ -214,6 +226,7 @@ def parse_command_line(program_info):
     program_info['encoding']= args.encoding
     program_info['comments'] = args.comments
     program_info['save_sensitive'] = args.save_sensitive
+    program_info['prefixcount'] = args.prefixcount
 
     # OMEN Options
     program_info['ngram'] = args.ngram
@@ -278,6 +291,7 @@ def main():
         'encoding':None,
         'comments':'',
         'save_sensitive': False,
+        'prefixcount': False,
 
         # OMEN Options
         'ngram': 4,


### PR DESCRIPTION
Same as #36 

But implemented differently, directly into the IO handling and not changing the training itself.

This comes at the cost of performance of course. Roughly 1-2s per 100.000 entries.

Performance of this branch (test_count ~250.000 entries):
```
time python3 trainer.py -t test_count.dict --prefixcount -r test

real    0m43.922s
user    0m43.571s
sys     0m0.350s
```

Other branch (#36)
```
time python3 trainer.py -t test_count.dict --prefixcount -r test

real    0m42.355s
user    0m42.054s
sys     0m0.300s
```

With the feature you are able to train on wordlist that have a count in front of them. Example:
Testdata.txt:
```
5 Password123!
6 Password321!
```

```
python3 trainer.py -t testdata.txt -r test --prefixcount -eutf8
```

Will result in Digit/3.txt:

```
321     0.5454545454545454
123     0.45454545454545453
```

Data can be generated with `sort | uniq -c | sort -rn`