### PR TITLE
Adding multiword pretraining

### DIFF
--- a/edit_rules.py
+++ b/edit_rules.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+
+"""
+
+Name: PCFG Rule Editor
+
+   Edit pretrained rules to make them match a password policy.
+
+Copyright 2021 Matt Weir
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Contact Info: cweir@vt.edu
+
+"""
+
+# Including this to print error message if python < 3.0 is used
+from __future__ import print_function
+import sys
+# Check for python3 and error out if not
+if sys.version_info[0] < 3:
+    print("This program requires Python 3.x", file=sys.stderr)
+    sys.exit(1)
+
+import argparse
+import os
+import shutil
+import re
+
+
+def parse_command_line(program_info):
+    # Keeping the title text to be generic to make re-using code easier
+    parser = argparse.ArgumentParser(
+        description= program_info['name'] +
+        ', version: ' + 
+        program_info['version']
+    )
+
+    parser.add_argument(
+        '--rule',
+        '-r',
+        help = 'Ruleset which will be edited.',
+        required = True,
+    )
+
+    parser.add_argument(
+        '--copy',
+        help = 'If used, instead on editing the ruleset, this option creats a copy which will be edited.',
+    )
+
+    parser.add_argument(
+        '--min_length',
+        help = 'If used, checks for the minimal length of grammars.',
+        default = 0,
+    )
+
+    parser.add_argument(
+        '--max_length',
+        help = 'If used, checks for the minimal length of grammars.',
+        default = 0,
+    )
+
+    parser.add_argument(
+        '--terminal_set',
+        help = 'Comma seperated of list of terminals to keep. Any grammar containing a terminal that is not in this list will be removed.',
+    )
+
+    parser.add_argument(
+        '--regex',
+        help = 'Comma seperated of list of regexes to check grammars. All regexes must match to keep the grammar. Usefull to filter on password policy.',
+    )
+
+
+    args=parser.parse_args()
+
+    # Standard Options
+    program_info['rule'] = args.rule
+    program_info['copy'] = args.copy
+    program_info['min_length'] = int(args.min_length)
+    program_info['max_length'] = int(args.max_length)
+    if args.terminal_set:
+        program_info['terminal_set'] = [x.upper() for x in args.terminal_set.split(',')]
+    else:
+        program_info['terminal_set'] = False
+    if args.regex:
+        program_info['regex'] = [x for x in args.regex.split(',')]
+    return True
+
+def _create_copy(rule_dir, output_dir):
+    shutil.copytree(rule_dir, output_dir)
+
+
+def check_regex(grammar, grammar_regex):
+    print('Checking grammars with regex...')
+    return_grammar = ''
+    for line in grammar.split('\n'):
+        if not line:
+            continue
+        structure = line.split('\t')[0]
+        prob = line.split('\t')[1]
+        prob = prob.strip()
+
+        stop = False
+        for regex in grammar_regex:
+            if re.search(regex, structure):
+                continue
+            else:
+                stop = True
+                break
+        
+        if not stop:
+            return_grammar += line
+            return_grammar += '\n'
+    return return_grammar
+
+
+def edit_terminal_set(grammar, terminal_set):
+    print('Checking grammars for terminals...')
+    return_grammar = ''
+    for line in grammar.split('\n'):
+        if not line:
+            continue
+        structure = line.split('\t')[0]
+        prob = line.split('\t')[1]
+        prob = prob.strip()
+
+        line = re.findall('[A-Z][0-9]{0,3}', line)
+        if not line:
+            print(f'Line containing invalid structure found {line}. Skipping.')
+            continue
+        skip = False
+        for x in line:
+            if x[0] not in terminal_set:
+                skip = True
+        if not skip:
+            return_grammar += ''.join(line) + '\t' + prob + '\n'
+    return return_grammar
+            
+
+def edit_length(grammar, min_length, max_length):
+    print('Checking length of gramamrs...')
+    return_grammar = ''
+    for line in grammar.split('\n'):
+        if not line:
+            continue
+        structure = line.split('\t')[0]
+        prob = line.split('\t')[1]
+        prob = prob.strip()
+
+        line = re.findall('[A-Z][0-9]{0,3}', line)
+        if not line:
+            print(f'Line containing invalid structure found {line}. Skipping.')
+            continue
+        
+        total_length = 0
+        for x in line:
+            if x[0] == 'A':
+                total_length += int(x[1:])
+            elif x[0] == 'D':
+                total_length += int(x[1:])
+            elif x[0] == 'Y':
+                total_length += 4
+            elif x[0] == 'O':
+                total_length += int(x[1:])
+            elif x[0] == 'K':
+                total_length += int(x[1:])
+            elif x[0] == 'X':
+                total_length += int(x[1:])
+        if not total_length and total_length <= max_length:
+            return_grammar += ''.join(line) + '\t' + prob + '\n'
+        elif total_length >= min_length and not max_length:
+            return_grammar += ''.join(line) + '\t' + prob + '\n'
+        elif total_length >= min_length and total_length <= max_length:
+            return_grammar += ''.join(line) + '\t' + prob + '\n'
+    
+    return return_grammar
+
+
+def edit_rules(config):
+    if config.get('copy'):
+        print(f'Creating copy of {config.get("copy")} to {config.get("rule")}')
+        _create_copy(os.path.join(config.get('rules_dir'), config.get('rule')),
+                    os.path.join(config.get('rules_dir'), config.get('copy')))
+        config['rule'] = config['copy']
+    
+    grammar_file = os.path.join(config.get('rules_dir'), config.get('rule'), 'Grammar', 'grammar.txt')
+    grammar = open(grammar_file, 'r').read()
+
+    if config.get('min_length') or config.get('max_length'):
+        grammar = edit_length(grammar, config.get('min_length'), config.get('max_length'))
+    if config.get('terminal_set'):
+        grammar = edit_terminal_set(grammar, config.get('terminal_set'))
+    if config.get('regex'):
+        grammar = check_regex(grammar, config.get('regex'))
+    with open(grammar_file, 'w') as grammar_fp:
+        print('Done editing, writing back results.')
+        for line in grammar:
+            grammar_fp.write(line)
+
+    return True
+
+def main():
+    # Information about this program
+    program_info = {
+        # Program and Contact Info
+        'name':'PCFG Edit Rules',
+        'version': '1.1',
+        'author':'Romke van Dijk',
+        'contact':'github.com@ocbios.nl',
+        'rules_dir': os.path.join(
+                        os.path.dirname(os.path.realpath(__file__)),
+                        'Rules',
+                     ),
+    }
+
+    print(program_info['name'])
+    print("Version: " + str(program_info['version']))
+
+    # Parsing the command line
+    if not parse_command_line(program_info):
+        # There was a problem with the command line so exit
+        print("Exiting...")
+        return
+   
+    if not edit_rules(program_info):
+        print('Error while editing rules. Exiting...')
+        return
+
+if __name__ == "__main__":
+    main()   
+

--- a/lib_trainer/detection_rules/multiword_detector.py
+++ b/lib_trainer/detection_rules/multiword_detector.py
@@ -64,7 +64,9 @@ class MultiWordDetector:
         #
         self.lookup = {}
 
-    def train(self, input_password):
+    # The set_threshold can be used to always set the min value when the word is first
+    # encountered. This is usefull when you have a pretrained word list.
+    def train(self, input_password, set_threshold=False):
         """
         Trains on an input passwords
 
@@ -121,8 +123,10 @@ class MultiWordDetector:
                     if run_len >= self.min_len:
                         # If the word hasn't been seen before
                         if "count" not in index:
-                            index["count"] = 1
-
+                            if set_threshold:
+                                index["count"] = self.threshold
+                            else:
+                                index["count"] = 1
                         else:
                             index["count"] += 1
 
@@ -136,7 +140,10 @@ class MultiWordDetector:
             if run_len >= self.min_len:
                 # If the word hasn't been seen before
                 if "count" not in index:
-                    index["count"] = 1
+                    if set_threshold:
+                        index["count"] = self.threshold
+                    else:
+                        index["count"] = 1
 
                 else:
                     index["count"] += 1

--- a/lib_trainer/future_research/my_leet_detector.py
+++ b/lib_trainer/future_research/my_leet_detector.py
@@ -342,16 +342,13 @@ class AsciiL33tDetector:
         file_input = TrainerFileInput(training_set, encoding)
         num_parsed_so_far = 0
         try:
-            password = file_input.read_password()
-            while password:
+            for password in file_input.read_password():
                 # Print status indicator if needed
                 num_parsed_so_far += 1
                 if num_parsed_so_far % 1000000 == 0:
                     print(str(num_parsed_so_far // 1000000) + ' Million')
                 # pcfg_parser.parse(password)
                 self.detect_l33t(password)
-                # Get the next password
-                password = file_input.read_password()
 
         except Exception as msg:
             traceback.print_exc(file=sys.stdout)

--- a/lib_trainer/run_trainer.py
+++ b/lib_trainer/run_trainer.py
@@ -57,7 +57,8 @@ def run_trainer(program_info, base_directory):
     # Initialize the file input to read passwords from
     file_input = TrainerFileInput(
                     program_info['training_file'],
-                    program_info['encoding'])
+                    program_info['encoding'],
+                    program_info['prefixcount'])
                     
     # Used for progress_bar
     num_parsed_so_far = 0
@@ -82,10 +83,21 @@ def run_trainer(program_info, base_directory):
                             min_len = 4,
                             max_len = 21)
 
+    if program_info['multiword']:
+        print("-------------------------------------------------")
+        print("Pretraining multiword detection.")
+        print("-------------------------------------------------")
+        print("")
+        multiword_input = TrainerFileInput(
+            program_info['multiword'],
+            program_info['encoding']
+        )
+        for multiword in multiword_input.read_password():
+            multiword_detector.train(multiword, set_threshold=True)
+
     # Loop until we hit the end of the file
     try:
-        password = file_input.read_password()
-        while password:
+        for password in file_input.read_password():
 
             # Print status indicator if needed
             num_parsed_so_far += 1
@@ -97,9 +109,6 @@ def run_trainer(program_info, base_directory):
             
             # Train multiword detector
             multiword_detector.train(password)
-
-            # Get the next password
-            password = file_input.read_password()
 
     except Exception as msg:
         print(f"Exception: {msg}")
@@ -137,7 +146,8 @@ def run_trainer(program_info, base_directory):
     # Re-Initialize the file input to read passwords from
     file_input = TrainerFileInput(
                     program_info['training_file'], 
-                    program_info['encoding'])
+                    program_info['encoding'],
+                    program_info['prefixcount'])
                     
     # Reset progress_bar
     num_parsed_so_far = 0
@@ -164,8 +174,7 @@ def run_trainer(program_info, base_directory):
     
     # Loop until we hit the end of the file
     try:
-        password = file_input.read_password()
-        while password:
+        for password in file_input.read_password():
         
             # Print status indicator if needed
             num_parsed_so_far += 1
@@ -177,9 +186,6 @@ def run_trainer(program_info, base_directory):
             
             # Parse the pcfg info
             pcfg_parser.parse(password)
-            
-            # Get the next password
-            password = file_input.read_password()
                         
     except Exception as msg:
         traceback.print_exc(file=sys.stdout)
@@ -203,7 +209,8 @@ def run_trainer(program_info, base_directory):
     # Re-Initialize the file input to read passwords from
     file_input = TrainerFileInput(
                     program_info['training_file'], 
-                    program_info['encoding'])
+                    program_info['encoding'],
+                    program_info['prefixcount'])
                     
     # Reset progress_bar
     num_parsed_so_far = 0
@@ -220,8 +227,7 @@ def run_trainer(program_info, base_directory):
     omen_levels_count = Counter()
     ## Loop until we hit the end of the file
     try:
-        password = file_input.read_password()
-        while password:
+        for password in file_input.read_password():
         
             # Print status indicator if needed
             num_parsed_so_far += 1
@@ -231,9 +237,6 @@ def run_trainer(program_info, base_directory):
             # Find OMEN level of password
             level = find_omen_level(omen_trainer,password)
             omen_levels_count[level] += 1
-            
-            # Get the next password
-            password = file_input.read_password()
         
     except Exception as msg:
         traceback.print_exc(file=sys.stdout)

--- a/lib_trainer/unit_tests/test_trainer_file_input.py
+++ b/lib_trainer/unit_tests/test_trainer_file_input.py
@@ -36,6 +36,7 @@ from ..trainer_file_input import TrainerFileInput
 # + Check Valid password: invalid password, blank
 # + Check Valid password: invalid password, tab in password
 # + Read Input Passwords (FULL): Check to make sure correct number are read
+# + Read Prefix Passwords (FULL): Check to make sure correct number are read when prefixed with a count
 #
 class Test_File_Input_Checks(unittest.TestCase):
 
@@ -137,19 +138,53 @@ class Test_File_Input_Checks(unittest.TestCase):
             unittest.mock.mock_open(read_data=test_data)
         ):
         
-            file_input = TrainerFileInput("test_file",'ascii')
+            file_input = TrainerFileInput("test_file",'ascii',False)
         
             # Loop through all of the passwords
-            password = file_input.read_password()
-            while password:
-                password = file_input.read_password()                     
+            for password in file_input.read_password():
+                continue
             
         # Verify the number of passwords read and the raw results
         print("Num passwords:" + str(file_input.num_passwords))
         assert file_input.num_passwords == 8
         
         assert file_input.duplicates_found == True
+
+    def test_read_input_passwords_prefix(self):
+    
+        # Set up input
+        raw_test_data = "5 test1\n" \
+            "5 test2\r\n" \
+            "\r\n" \
+            "invalid1\t" \
+            "5 test3\n" \
+            "\n" \
+            "5 space1 \n" \
+            "5 space2\n" \
+            "5 sp ace3\n" \
+            "5 duplicate\n" \
+            "5 duplicate\r\r\n" \
+            "5 test4"
+        
+        test_data = raw_test_data
+        
+        # Patch file open and read data
+        with unittest.mock.patch(
+            'codecs.open', 
+            unittest.mock.mock_open(read_data=test_data)
+        ):
+        
+            file_input = TrainerFileInput("test_file",'ascii', prefixcount=True)
+        
+            # Loop through all of the passwords
+            for password in file_input.read_password():
+                continue
             
+        # Verify the number of passwords read and the raw results
+        assert file_input.num_passwords == 40
+        
+        assert file_input.duplicates_found == True
+
 
 if __name__ == '__main__':
     unittest.main()             

--- a/password_scorer.py
+++ b/password_scorer.py
@@ -236,7 +236,8 @@ def main():
     # Re-using the TrainerFileInput from the trainer
     file_input = TrainerFileInput(
                     program_info['input_file'],
-                    pw_parser.encoding)
+                    pw_parser.encoding,
+                    program_info['prefixcount'])
 
     # Open file for output
     writer = FileOutput(program_info['output_file'], pw_parser.encoding)

--- a/trainer.py
+++ b/trainer.py
@@ -133,6 +133,18 @@ def parse_command_line(program_info):
         action='store_true'
     )
 
+   # Prefix count
+    parser.add_argument(
+        '--prefixcount',
+        help = 'When enabled lines must be prefixed with a occurrences counter. Example:' +
+        '5 password123!. Meaning that password123! was 5 times in the dataset. This can happen ' +
+        'for dataset which were sorted and uniqued with sort | uniq -c | sort -rn for example. Default: ' +
+        str(program_info['prefixcount']),
+        default = program_info['prefixcount'],
+        action = 'store_true',
+        required = False,
+    )
+
     ## OMEN Options
     #
     # ngram is the size of the conditional probabilty strings to compare
@@ -206,6 +218,16 @@ def parse_command_line(program_info):
         default = program_info['coverage'],
         type = float
     )
+
+    # Multiword training file
+    parser.add_argument(
+        '--multiword',
+        '-m',
+        help = '<ADVANCED> File containing words to pre-train multiword detection',
+        metavar = 'MULTIWORD',
+        required = False,
+    )
+
     # Parse all the args and save them
     args=parser.parse_args()
     # Standard Options
@@ -214,6 +236,7 @@ def parse_command_line(program_info):
     program_info['encoding']= args.encoding
     program_info['comments'] = args.comments
     program_info['save_sensitive'] = args.save_sensitive
+    program_info['prefixcount'] = args.prefixcount
 
     # OMEN Options
     program_info['ngram'] = args.ngram
@@ -222,6 +245,7 @@ def parse_command_line(program_info):
     # Advanced Options
     #program_info['smoothing'] = args.smoothing
     program_info['coverage'] = args.coverage
+    program_info['multiword'] = args.multiword
 
     ## Sanity checking of values
     #
@@ -278,6 +302,7 @@ def main():
         'encoding':None,
         'comments':'',
         'save_sensitive': False,
+        'prefixcount': False,
 
         # OMEN Options
         'ngram': 4,


### PR DESCRIPTION
When working with PCFG and a small training set the multiword doesn't work. With the feature you can pretrain the multiword detector the detect the multiword even in small trainingsets.

This code works with the current master, but if #36 or #37 are merged the TODO needs to be implemented :).

How to use:

```
$ cat multiword.txt
password
$ cat testdataset.txt
PasswordPassword123!
```

```
$ python3 trainer.py -r test -t testdataset.txt -m multiword.txt -e utf8
```

Result:
```
$ cat Rules/test/Grammar/grammar.txt
A8A8D3O1        0.6
M       0.4
$ cat Rules/test/Alpha/8.txt
password        1.0
```
