### PR TITLE
Adding multiword pretraining

### DIFF
--- a/lib_trainer/detection_rules/multiword_detector.py
+++ b/lib_trainer/detection_rules/multiword_detector.py
@@ -64,7 +64,9 @@ class MultiWordDetector:
         #
         self.lookup = {}
 
-    def train(self, input_password):
+    # The set_threshold can be used to always set the min value when the word is first
+    # encountered. This is usefull when you have a pretrained word list.
+    def train(self, input_password, set_threshold=False):
         """
         Trains on an input passwords
 
@@ -121,7 +123,10 @@ class MultiWordDetector:
                     if run_len >= self.min_len:
                         # If the word hasn't been seen before
                         if "count" not in index:
-                            index["count"] = 1
+                            if set_threshold:
+                                index["count"] = self.threshold
+                            else:
+                                index["count"] = 1
 
                         else:
                             index["count"] += 1
@@ -136,7 +141,10 @@ class MultiWordDetector:
             if run_len >= self.min_len:
                 # If the word hasn't been seen before
                 if "count" not in index:
-                    index["count"] = 1
+                    if set_threshold:
+                        index["count"] = self.threshold
+                    else:
+                        index["count"] = 1
 
                 else:
                     index["count"] += 1

--- a/lib_trainer/run_trainer.py
+++ b/lib_trainer/run_trainer.py
@@ -83,6 +83,18 @@ def run_trainer(program_info, base_directory):
                             min_len = 4,
                             max_len = 21)
 
+    if program_info['multiword']:
+        print("-------------------------------------------------")
+        print("Pretraining multiword detection.")
+        print("-------------------------------------------------")
+        print("")
+        multiword_input = TrainerFileInput(
+            program_info['multiword'],
+            program_info['encoding']
+        )
+        for multiword in multiword_input.read_password():
+            multiword_detector.train(multiword, set_threshold=True)
+
     # Loop until we hit the end of the file
     try:
         for password in file_input.read_password():

--- a/trainer.py
+++ b/trainer.py
@@ -218,6 +218,16 @@ def parse_command_line(program_info):
         default = program_info['coverage'],
         type = float
     )
+
+    # Multiword training file
+    parser.add_argument(
+        '--multiword',
+        '-m',
+        help = '<ADVANCED> File containing words to pre-train multiword detection',
+        metavar = 'MULTIWORD',
+        required = False,
+    )
+
     # Parse all the args and save them
     args=parser.parse_args()
     # Standard Options
@@ -235,6 +245,7 @@ def parse_command_line(program_info):
     # Advanced Options
     #program_info['smoothing'] = args.smoothing
     program_info['coverage'] = args.coverage
+    program_info['multiword'] = args.multiword
 
     ## Sanity checking of values
     #
@@ -302,6 +313,7 @@ def main():
         'smoothing': 0.01,
         'coverage':0.6,
         'max_len':21,
+        'multiword': False
     }
 
     print_banner()


### PR DESCRIPTION
This items replaces #39 

When working with PCFG and a small training set the multiword doesn't work. With the feature you can pretrain the multiword detector the detect the multiword even in small trainingsets.

How to use:

```
$ cat multiword.txt
password
$ cat testdataset.txt
PasswordPassword123!
```

```
$ python3 trainer.py -r test -t testdataset.txt -m multiword.txt -e utf8
```

Result:
```
$ cat Rules/test/Grammar/grammar.txt
A8A8D3O1        0.6
M       0.4
$ cat Rules/test/Alpha/8.txt
password        1.0
```
