### PR TITLE
Fixing obsolete function preventing execution on latest python3

### DIFF
--- a/lib_guesser/grammar_io.py
+++ b/lib_guesser/grammar_io.py
@@ -373,7 +373,7 @@ def _load_config(ruleset_info, base_directory, config):
 
     # Attempt to read the config from disk
     try:
-        config.readfp(open(os.path.join(base_directory,"config.ini")))
+        config.read_file(open(os.path.join(base_directory,"config.ini")))
 
         ## Check the version
         #

--- a/lib_scorer/grammar_io.py
+++ b/lib_scorer/grammar_io.py
@@ -39,7 +39,7 @@ def load_grammar(grammar, rule_directory):
     config = configparser.ConfigParser()
 
     try:
-        config.readfp(open(os.path.join(rule_directory,"config.ini")))
+        config.read_file(open(os.path.join(rule_directory,"config.ini")))
 
         # Find the encoding for the config file
         grammar.encoding = config.get('TRAINING_DATASET_DETAILS','encoding')


### PR DESCRIPTION
Fixing: https://github.com/lakiw/pcfg_cracker/issues/45
Caused by an obsolete function. Replaced with read_file.