### PR TITLE
Remove readlines to avoid memory blowup

### DIFF
--- a/lib_trainer/trainer_file_input.py
+++ b/lib_trainer/trainer_file_input.py
@@ -98,7 +98,7 @@ def detect_file_encoding(training_file, file_encoding, max_passwords = 500000):
     try:
         cur_count = 0
         with open(training_file, 'rb') as file:
-            for line in file.readlines():
+            for line in file:
             
                 # Check for a $HEX[] encoded password 
                 end_bracket_pos = line.find(bytes("]", "ascii"))
@@ -369,3 +369,4 @@ class TrainerFileInput:
             print (error)
             print ("Error reading file " + self.filename)
             raise
+


### PR DESCRIPTION
The `readlines()` functions loads the whole file into memory before it even starts iterating over the lines. With larger files this is an unnecessary step as the encoding detection only wants to read the first few lines for detection and then stops when reaching max_passwords.

Instead just `for line in file:` can be used to iterate over the opened file without loading it completely and then stop when done.